### PR TITLE
Change nrOfColumns field to size_t type

### DIFF
--- a/sqlite/sqlite-database.h
+++ b/sqlite/sqlite-database.h
@@ -29,7 +29,7 @@
 namespace katla {
 
 struct SqliteTableData {
-    int nrOfColumns {};
+    size_t nrOfColumns {};
     std::vector<std::string> columnNames;
     std::vector<std::string> data;
 };


### PR DESCRIPTION
This type is more appropriate as this is quantity that cannot be negative. This update fixes various sign-compare warnings in our codebase, where we compare this against collection size().