### PR TITLE
Fix: Error in wait time calculation

### DIFF
--- a/core/worker-thread.cpp
+++ b/core/worker-thread.cpp
@@ -101,9 +101,6 @@ void WorkerThread::exec(const std::function<void(void)>& repeatableWork)
 
     std::chrono::milliseconds waitTime = m_interval;
     while (true) {
-        Stopwatch stopwatch;
-        stopwatch.start();
-
         {
             std::unique_lock<std::mutex> lock(m_mutex);
 
@@ -113,6 +110,8 @@ void WorkerThread::exec(const std::function<void(void)>& repeatableWork)
             m_wakeUp = false;
         }
 
+        Stopwatch stopwatch;
+        stopwatch.start();
         std::invoke(repeatableWork);
 
         // Calculate wait time so that task is invoked at requested interval when possible.


### PR DESCRIPTION
As it turns out, my previous fix was itself faulty. It was measuring the time including the previous wait but should have measured only the task execution itself.