### PR TITLE
Gracefully handle format exceptions

### DIFF
--- a/core/core.h
+++ b/core/core.h
@@ -52,12 +52,24 @@ namespace katla {
      */
     template <typename S, typename... Args>
     inline std::string format(const S& format_str, Args&&... args) {
-        return fmt::format(format_str, args...);
+        try {
+            return fmt::format(format_str, args...);
+        }
+        catch (...) {
+            // Gracefully handle thrown exceptions, which may occur when fewer arguments are
+            // passed than required by the format string. This helps to avoid run-time crashes,
+            // which could occur when formatting logs and errors for exceptional scenarios.
+            //
+            // This won't be needed after switching to std::format, as it will raise an error
+            // at compile time instead.
+
+            return format_str;
+        }
     }
 
     template <typename S, typename... Args>
     inline void print(std::FILE* f, const S& format_str, Args&&... args) {
-        fmt::print(f, format_str, args...);
+        fmt::print(format(format_str, args...));
     }
 
     template <typename S, typename... Args>

--- a/core/core.h
+++ b/core/core.h
@@ -61,7 +61,7 @@ namespace katla {
             // which could occur when formatting logs and errors for exceptional scenarios.
             //
             // This won't be needed after switching to std::format, as it will raise an error
-            // at compile time instead.
+            // at compile-time instead.
 
             return format_str;
         }
@@ -69,7 +69,9 @@ namespace katla {
 
     template <typename S, typename... Args>
     inline void print(std::FILE* f, const S& format_str, Args&&... args) {
-        fmt::print(format(format_str, args...));
+        // Use print (as a means to output char[], std::string, and other string types to file)
+        // but do not use its built-in formatting on the passed format string to avoid exceptions.
+        fmt::print(f, "{}", format(format_str, args...));
     }
 
     template <typename S, typename... Args>


### PR DESCRIPTION
This change helps to prevent crashes due to format exceptions.

A drawback is that it may make formatting errors less noticeable. However, this is mitigated by still outputting the format specifier, so that format errors can still be noticed.

This is only temporarily needed, as there is no need anymore once using std::format, as this results in compile-time errors instead.